### PR TITLE
docs: MusicDecoy is actually a cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ## Installation
 
 - Download, unzip, move to `/Applications`
-- or.. `brew install music-decoy`
+- or.. `brew install --cask music-decoy`
 
 
 ## What does this do?


### PR DESCRIPTION
Since MusicDecoy is a Homebrew Cask, we need to pass the `--cask` option.

ref: https://formulae.brew.sh/cask/music-decoy