### PR TITLE
fix: add Music scripting compatibility to prevent VLC crashes

### DIFF
--- a/Music Decoy.xcodeproj/project.pbxproj
+++ b/Music Decoy.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		C74B66BD2AF1661100F8A72D /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = C74B66BB2AF1661100F8A72D /* MainMenu.xib */; };
 		C74B66BF2AF1661100F8A72D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C74B66BE2AF1661100F8A72D /* main.m */; };
 		C74B66C82AF1728200F8A72D /* LaunchAtLoginController.m in Sources */ = {isa = PBXBuildFile; fileRef = C74B66C62AF1728200F8A72D /* LaunchAtLoginController.m */; };
+		C74B66D12AF1800000F8A72D /* MusicDecoyApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = C74B66D02AF1800000F8A72D /* MusicDecoyApplication.m */; };
+		C74B66D42AF1800000F8A72D /* MusicDecoy.sdef in Resources */ = {isa = PBXBuildFile; fileRef = C74B66D32AF1800000F8A72D /* MusicDecoy.sdef */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +25,10 @@
 		C74B66BE2AF1661100F8A72D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		C74B66C62AF1728200F8A72D /* LaunchAtLoginController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LaunchAtLoginController.m; sourceTree = "<group>"; };
 		C74B66C72AF1728200F8A72D /* LaunchAtLoginController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LaunchAtLoginController.h; sourceTree = "<group>"; };
+		C74B66CE2AF1800000F8A72D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C74B66CF2AF1800000F8A72D /* MusicDecoyApplication.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MusicDecoyApplication.h; sourceTree = "<group>"; };
+		C74B66D02AF1800000F8A72D /* MusicDecoyApplication.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MusicDecoyApplication.m; sourceTree = "<group>"; };
+		C74B66D32AF1800000F8A72D /* MusicDecoy.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = MusicDecoy.sdef; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -57,8 +63,12 @@
 			children = (
 				C74B66C72AF1728200F8A72D /* LaunchAtLoginController.h */,
 				C74B66C62AF1728200F8A72D /* LaunchAtLoginController.m */,
+				C74B66CE2AF1800000F8A72D /* Info.plist */,
+				C74B66CF2AF1800000F8A72D /* MusicDecoyApplication.h */,
+				C74B66D02AF1800000F8A72D /* MusicDecoyApplication.m */,
 				C74B66B62AF1661000F8A72D /* AppDelegate.h */,
 				C74B66B72AF1661000F8A72D /* AppDelegate.m */,
+				C74B66D32AF1800000F8A72D /* MusicDecoy.sdef */,
 				C74B66B92AF1661100F8A72D /* Assets.xcassets */,
 				C74B66BB2AF1661100F8A72D /* MainMenu.xib */,
 				C74B66BE2AF1661100F8A72D /* main.m */,
@@ -124,6 +134,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C74B66BA2AF1661100F8A72D /* Assets.xcassets in Resources */,
+				C74B66D42AF1800000F8A72D /* MusicDecoy.sdef in Resources */,
 				C74B66BD2AF1661100F8A72D /* MainMenu.xib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -136,6 +147,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C74B66C82AF1728200F8A72D /* LaunchAtLoginController.m in Sources */,
+				C74B66D12AF1800000F8A72D /* MusicDecoyApplication.m in Sources */,
 				C74B66BF2AF1661100F8A72D /* main.m in Sources */,
 				C74B66B82AF1661000F8A72D /* AppDelegate.m in Sources */,
 			);
@@ -279,13 +291,8 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = RDDXV84A73;
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "Music Decoy";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_LSBackgroundOnly = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSMainNibFile = MainMenu;
-				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Music/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -307,13 +314,8 @@
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = RDDXV84A73;
 				ENABLE_HARDENED_RUNTIME = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "Music Decoy";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
-				INFOPLIST_KEY_LSBackgroundOnly = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSMainNibFile = MainMenu;
-				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = Music/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/Music/AppDelegate.m
+++ b/Music/AppDelegate.m
@@ -7,6 +7,7 @@
 
 #import "AppDelegate.h"
 #import "LaunchAtLoginController.h"
+#import "MusicDecoyApplication.h"
 
 @interface AppDelegate ()
 @property (nonatomic, strong) NSUserDefaults *defaults;
@@ -22,6 +23,15 @@
     self.defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.lowtechguys.MusicDecoy"];
     [self.defaults addObserver:self forKeyPath:@"mediaAppPath" options:0 context:NULL];
     [self updateActivationPolicy];
+
+    [[NSAppleEventManager sharedAppleEventManager] setEventHandler:NSApp
+                                                      andSelector:@selector(handlePlayPauseAppleEvent:withReplyEvent:)
+                                                    forEventClass:'hook'
+                                                       andEventID:'PlPs'];
+    [[NSAppleEventManager sharedAppleEventManager] setEventHandler:NSApp
+                                                      andSelector:@selector(handlePlayPauseAppleEvent:withReplyEvent:)
+                                                    forEventClass:'hook'
+                                                       andEventID:'Play'];
 }
 
 - (void)updateActivationPolicy {
@@ -43,18 +53,7 @@
 - (void)applicationDidBecomeActive:(NSNotification *)notification {
     // LSBackgroundOnly means no launch activation, so this only fires while we're
     // Accessory, i.e. mediaAppPath is set and Play was pressed.
-    NSString *appPath = [self.defaults stringForKey:@"mediaAppPath"];
-    if (!appPath) {
-        return;
-    }
-
-    NSString *bundleIdentifier = [[NSBundle bundleWithPath:appPath] bundleIdentifier];
-    NSArray<NSRunningApplication *> *running = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier];
-    if (running.count) {
-        [running.firstObject activateWithOptions:0]; // already running: bring it forward
-    } else {
-        [[NSWorkspace sharedWorkspace] launchApplication:appPath]; // launch it
-    }
+    [(MusicDecoyApplication *)NSApp launchConfiguredMediaApp];
 }
 
 @end

--- a/Music/Info.plist
+++ b/Music/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Music Decoy</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.utilities</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSAppleScriptEnabled</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string></string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>MusicDecoyApplication</string>
+	<key>OSAScriptingDefinition</key>
+	<string>MusicDecoy.sdef</string>
+</dict>
+</plist>

--- a/Music/MusicDecoy.sdef
+++ b/Music/MusicDecoy.sdef
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE dictionary SYSTEM "file://localhost/System/Library/DTDs/sdef.dtd">
+<dictionary title="Music Decoy Terminology">
+    <suite name="Music Suite" code="hook" description="Compatibility terms for media apps that script Apple Music">
+        <command name="pause" code="hookPaus" description="No-op pause command">
+            <cocoa method="pause:"/>
+        </command>
+        <command name="playpause" code="hookPlPs" description="No-op play/pause command">
+            <cocoa method="playpause:"/>
+        </command>
+        <command name="resume" code="hookResu" description="No-op resume command">
+            <cocoa method="resume:"/>
+        </command>
+        <command name="stop" code="hookStop" description="No-op stop command">
+            <cocoa method="stop:"/>
+        </command>
+        <class name="application" code="capp" description="The application program">
+            <cocoa class="MusicDecoyApplication"/>
+            <property name="player state" code="pPlS" type="ePlS" access="r" description="Always stopped">
+                <cocoa key="playerState"/>
+            </property>
+        </class>
+        <enumeration name="ePlS" code="ePlS">
+            <enumerator name="stopped" code="kPSS"/>
+            <enumerator name="playing" code="kPSP"/>
+            <enumerator name="paused" code="kPSp"/>
+            <enumerator name="fast forwarding" code="kPSF"/>
+            <enumerator name="rewinding" code="kPSR"/>
+        </enumeration>
+    </suite>
+</dictionary>

--- a/Music/MusicDecoyApplication.h
+++ b/Music/MusicDecoyApplication.h
@@ -1,0 +1,14 @@
+//
+//  MusicDecoyApplication.h
+//  Music Decoy
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface MusicDecoyApplication : NSApplication
+
+- (void)launchConfiguredMediaApp;
+- (void)handlePlayPauseAppleEvent:(NSAppleEventDescriptor *)event
+                   withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
+
+@end

--- a/Music/MusicDecoyApplication.m
+++ b/Music/MusicDecoyApplication.m
@@ -1,0 +1,71 @@
+//
+//  MusicDecoyApplication.m
+//  Music Decoy
+//
+
+#import "MusicDecoyApplication.h"
+
+typedef NS_ENUM(OSType, MusicDecoyPlayerState) {
+    MusicDecoyPlayerStateStopped = 'kPSS',
+};
+
+@implementation MusicDecoyApplication
+
+- (NSNumber *)playerState {
+    return @(MusicDecoyPlayerStateStopped);
+}
+
+- (void)launchConfiguredMediaApp {
+    NSUserDefaults *defaults = [[NSUserDefaults alloc] initWithSuiteName:@"com.lowtechguys.MusicDecoy"];
+    NSString *appPath = [defaults stringForKey:@"mediaAppPath"];
+    if (!appPath) {
+        return;
+    }
+
+    NSBundle *bundle = [NSBundle bundleWithPath:appPath];
+    NSString *bundleIdentifier = bundle.bundleIdentifier;
+    if (!bundleIdentifier) {
+        [self launchApplicationAtPath:appPath];
+        return;
+    }
+
+    NSArray<NSRunningApplication *> *running = [NSRunningApplication runningApplicationsWithBundleIdentifier:bundleIdentifier];
+    if (running.count) {
+        [running.firstObject activateWithOptions:0];
+    } else {
+        [self launchApplicationAtPath:appPath];
+    }
+}
+
+- (void)launchApplicationAtPath:(NSString *)appPath {
+    NSURL *appURL = [NSURL fileURLWithPath:appPath];
+    if (@available(macOS 10.15, *)) {
+        NSWorkspaceOpenConfiguration *configuration = [NSWorkspaceOpenConfiguration configuration];
+        configuration.activates = YES;
+        [[NSWorkspace sharedWorkspace] openApplicationAtURL:appURL
+                                              configuration:configuration
+                                          completionHandler:nil];
+    } else {
+        [[NSWorkspace sharedWorkspace] launchApplication:appPath];
+    }
+}
+
+- (void)pause:(NSScriptCommand *)command {
+}
+
+- (void)playpause:(NSScriptCommand *)command {
+    [self launchConfiguredMediaApp];
+}
+
+- (void)handlePlayPauseAppleEvent:(NSAppleEventDescriptor *)event
+                   withReplyEvent:(NSAppleEventDescriptor *)replyEvent {
+    [self launchConfiguredMediaApp];
+}
+
+- (void)resume:(NSScriptCommand *)command {
+}
+
+- (void)stop:(NSScriptCommand *)command {
+}
+
+@end


### PR DESCRIPTION
## Summary

VLC can now query Music Decoy as if it were Apple Music without crashing. The app exposes a minimal scripting definition for the Apple Music terms VLC asks for, returning `stopped` for `player state` and accepting the common playback commands as no-ops.

The existing `mediaAppPath` behaviour is preserved: when the Play fallback or a `playpause` AppleEvent reaches Music Decoy, it still launches or activates the configured media app, such as Spotify.

References FuzzyIdeas/MusicDecoy#3.

## Notes

This keeps the scripting surface intentionally small. It does not try to emulate Apple Music playback, library, or track state beyond the terms needed to stop ScriptingBridge clients from treating Music Decoy as a non-scriptable `com.apple.Music` app.

## Review

I reviewed the patch for the two main regressions this app needs to avoid:

1. Music Decoy still builds with `LSBackgroundOnly` and keeps the existing activation-policy behaviour, so the app should not grow a Dock icon or steal focus in the default no-configuration case.
2. The configured app launch path is shared between `applicationDidBecomeActive`, `playpause`, and direct Play AppleEvents, so the VLC compatibility fix does not remove the existing "press Play to open Spotify" workflow.

No blocking issues found in the patch review.

## Verification

1. Built Release successfully with:

   `xcodebuild -project 'Music Decoy.xcodeproj' -scheme 'Music Decoy' -configuration Release -derivedDataPath /tmp/MusicDecoyDerivedPR build CODE_SIGNING_ALLOWED=NO`

2. Verified the built app's scripting dictionary exposes `player state`, `stopped`, and the playback commands with:

   `sdef '/tmp/MusicDecoyDerivedPR/Build/Products/Release/Music Decoy.app'`

3. Verified the built app's plist contains `CFBundleIdentifier = com.apple.Music`, `NSAppleScriptEnabled`, `NSPrincipalClass = MusicDecoyApplication`, and `OSAScriptingDefinition = MusicDecoy.sdef`.

4. Manually tested an installed build locally:

   `tell application "/Applications/Music Decoy.app" to player state` returns `stopped`, VLC no longer crashes when starting playback, and the hardware Play key still opens the configured Spotify app once other active media sessions, such as Chrome playback, are cleared.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
